### PR TITLE
feat(footer): add mailto link to contact us section

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -24,7 +24,9 @@
         <h4 class="font-bold mb-3 text-sm">關於我們</h4>
         <ul class="text-xs text-gray-400 space-y-1">
           <li>服務項目</li>
-          <li>聯繫方式</li>
+          <li>
+            <a href="mailto:eathubtw@gmail.com" class=" hover:underline">聯絡我們</a>
+          </li>
           <li>
             <RouterLink to="/terms-of-service" class="hover:underline">條款與政策</RouterLink>
           </li>


### PR DESCRIPTION
closes #66 

更新在Footer的「聯絡我們」 新增了 mailto: 連結，讓使用者可以點擊後直接開啟預設的電子郵件程式撰寫信件
![image](https://github.com/user-attachments/assets/825947c1-5a6d-40c8-860c-39acaf1c6841)
![image](https://github.com/user-attachments/assets/a7bdf667-05e3-4c8b-9784-46f8edf8c213)
