### PR TITLE
fix: restore merchant NavBar on merchant pages accidentally removed 

### DIFF
--- a/src/views/CouponDetail.vue
+++ b/src/views/CouponDetail.vue
@@ -1,4 +1,5 @@
 <template>
+  <MerchantNavBar />
   <div class="max-w-3xl w-full mx-auto p-6">
     <h1 class="text-2xl font-bold mb-4">{{ coupon.title }}</h1>
 


### PR DESCRIPTION
closes #152 



修正商家頁面導覽列被合併覆蓋的問題
在先前解衝突過程，原本已加入商家相關頁面的 Merchant NavBar 不小心被覆蓋，導致導覽列消失。
此 issue 補回該導覽列，恢復原本應有的畫面結構與使用體驗，未新增任何功能。

![Image](https://github.com/user-attachments/assets/6949999d-3f02-4fa4-8914-bc4708607870)
被覆蓋以後NavBar 消失 





補回NavBar 頁面：
![image](https://github.com/user-attachments/assets/9b802f33-5190-455f-955c-3683ce0ce483)
