### PR TITLE
feat: add modal for merchant user upgrade to VIP

### DIFF
--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center">
+  <div class="fixed inset-0  bg-[rgba(0,0,0,0.9)]  z-50 flex justify-center items-center">
     <div class="bg-white p-6 rounded-lg shadow-md max-w-md w-full">
 
       <!-- 升級訊息 -->

--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="modal bg-white p-6 rounded-lg shadow-md">
+    <!-- Optional message -->
+    <div v-if="message" class="mb-4 text-sm text-orange-600 bg-orange-100 p-2 rounded">
+      ⚠️ {{ message }}
+    </div>
+
+    <!-- Tab switch -->
+    <div class="flex gap-4 mb-4">
+      <button
+        v-for="plan in plans"
+        :key="plan.plan_type"
+        :class="activePlan === plan.plan_type ? 'btn-primary' : 'btn-outline'"
+        @click="activePlan = plan.plan_type"
+      >
+        {{ plan.plan_type === 'monthly' ? '按月付款' : '按年付款' }}
+      </button>
+    </div>
+
+    <!-- Content from backend -->
+    <div v-if="currentPlan">
+      <p class="text-sm mb-2">價格：NT${{ currentPlan.amount }}</p>
+      <div class="flex gap-3">
+        <button class="btn btn-success" @click="pay('linepay')">LINEPAY</button>
+        <button class="btn btn-outline" @click="pay('ecpay')">綠界支付</button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -1,29 +1,77 @@
 <template>
-  <div class="modal bg-white p-6 rounded-lg shadow-md">
-    <!-- Optional message -->
-    <div v-if="message" class="mb-4 text-sm text-orange-600 bg-orange-100 p-2 rounded">
-      ⚠️ {{ message }}
-    </div>
+  <div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center">
+    <div class="bg-white p-6 rounded-lg shadow-md max-w-md w-full">
 
-    <!-- Tab switch -->
-    <div class="flex gap-4 mb-4">
-      <button
-        v-for="plan in plans"
-        :key="plan.plan_type"
-        :class="activePlan === plan.plan_type ? 'btn-primary' : 'btn-outline'"
-        @click="activePlan = plan.plan_type"
-      >
-        {{ plan.plan_type === 'monthly' ? '按月付款' : '按年付款' }}
-      </button>
-    </div>
+      <!-- 升級訊息 -->
+      <div v-if="message" class="mb-4 text-sm text-orange-600 bg-orange-100 p-2 rounded">
+        ⚠️ {{ message }}
+      </div>
 
-    <!-- Content from backend -->
-    <div v-if="currentPlan">
-      <p class="text-sm mb-2">價格：NT${{ currentPlan.amount }}</p>
-      <div class="flex gap-3">
-        <button class="btn btn-success" @click="pay('linepay')">LINEPAY</button>
-        <button class="btn btn-outline" @click="pay('ecpay')">綠界支付</button>
+
+      <!-- 升級固定說明 -->
+      <div class="mb-4 text-sm text-gray-700 flex items-center gap-2">
+        <font-awesome-icon :icon="['fa-solid', 'fa-crown']" class="text-yellow-500" />
+        <span>
+            <div>升級為 VIP 店家可發佈更多優惠券與動態，享更多專屬權益</div>
+            <div>VIP 店家優惠券與動態可各發佈至多 3 則 </div>
+        </span>
+      </div>
+
+
+      
+
+      <!-- Tab 切換 -->
+      <div class="flex gap-4 mb-4">
+        <button
+          v-for="plan in plans"
+          :key="plan.plan_type"
+          class="btn"
+          :class="activePlan === plan.plan_type ? 'btn-primary' : 'btn-outline'"
+          @click="activePlan = plan.plan_type"
+        >
+          {{ plan.plan_type === 'monthly' ? '按月付款' : '按年付款' }}
+        </button>
+      </div>
+
+      <!-- 價格顯示 -->
+      <div class="mb-2 text-sm">
+        價格：
+        <template v-if="currentPlan">
+          NT${{ currentPlan.amount }}
+        </template>
+        <template v-else>
+          <span class="text-gray-500">目前尚未開放購買方案，請稍後再試。</span>
+        </template>
+      </div>
+
+      <!-- 關閉按鈕 -->
+      <div class="mt-6 text-right">
+        <button class="btn btn-sm" @click="$emit('close')">關閉</button>
       </div>
     </div>
   </div>
 </template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import axios from '@/axios'
+
+// 傳入 props
+defineProps({ message: String })
+
+// 狀態管理
+const activePlan = ref('monthly')
+const plans = ref([])
+
+// 動態計算目前方案
+const currentPlan = computed(() =>
+  plans.value.find(p => p.plan_type === activePlan.value)
+)
+
+onMounted(async () => {
+
+    const res = await axios.get('/api/products/')
+    plans.value = res.data.results
+
+})
+</script>

--- a/src/views/MerchantDashboard.vue
+++ b/src/views/MerchantDashboard.vue
@@ -12,9 +12,9 @@
     </h1>
     <p v-if="role === 'merchant'"  class="text-sm text-gray-600 mb-4">
       您目前為 <span class="font-semibold text-primary">一般商家</span>，升級為 VIP 可發佈更多優惠券與活動 
-      <span class="badge badge-primary underline ml-1">
+      <button  @click="openUpgradeModal()" class=" inline-flex items-center gap-1 text-xs font-semibold text-white bg-orange-500 px-3 py-1 rounded-full hover:bg-orange-600 transition ml-2">
         <font-awesome-icon :icon="['fa-solid', 'fa-crown']" />  立即升級！ 
-      </span>
+      </button>
     </p>
 
     <!-- Tab 與新增按鈕 -->
@@ -60,6 +60,12 @@
     />
   </div>
 
+    <UpgradeModal
+    v-if="showUpgradeModal"
+    :message="upgradeMessage"
+    @close="showUpgradeModal = false"
+    />
+
   <component :is="Footer" />
 </template>
 
@@ -71,6 +77,7 @@ import MerchantNavBar from '@/components/MerchantNavBar.vue';
 import Footer from '@/components/Footer.vue';
 import MerchantCouponList from '@/components/MerchantCouponList.vue';
 import MerchantPromotionList from '@/components/MerchantPromotionList.vue';
+import UpgradeModal from '@/components/MerchantUpgradeModal.vue'
 
 const route = useRoute();
 const router = useRouter();
@@ -98,6 +105,13 @@ const fetchDashboard = async () => {
     console.error('取得商家資料失敗:', err);
   }
 };
+
+const showUpgradeModal = ref(false)
+const upgradeMessage = ref(null)
+const openUpgradeModal = (message = null) => {
+  upgradeMessage.value = message
+  showUpgradeModal.value = true
+}
 
 onMounted(fetchDashboard);
 </script>


### PR DESCRIPTION
closes #160 
新增一般店家升級Modal ：

![Image](https://github.com/user-attachments/assets/7243344b-8218-4976-9665-144f308d8384)


操作影片：
https://github.com/user-attachments/assets/e2fa4108-823a-4e29-bde8-6f141854bdb5


目前已處理：
新增Modal
點擊『立即升級』會開啓Modal

後續待處理（另開 issue）
Modal 內容 -  月付、年付 方案內容（待後端提供方案內容API）
付款方式 - 待金流完成
