### PR TITLE
feat(MerchantUpgradeModal): integrate backend pricing API for plan data

### DIFF
--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -24,12 +24,12 @@
       <div class="flex gap-4 mb-4">
         <button
           v-for="plan in plans"
-          :key="plan.plan_type"
+          :key="plan.planType"
           class="btn"
-          :class="activePlan === plan.plan_type ? 'btn-primary' : 'btn-outline'"
-          @click="activePlan = plan.plan_type"
+          :class="activePlan === plan.planType ? 'btn-primary' : 'btn-outline'"
+          @click="activePlan = plan.planType"
         >
-          {{ plan.plan_type === 'monthly' ? '按月付款' : '按年付款' }}
+          {{ plan.planType === 'monthly' ? '按月付款' : '按年付款' }}
         </button>
       </div>
 
@@ -65,13 +65,13 @@ const plans = ref([])
 
 // 動態計算目前方案
 const currentPlan = computed(() =>
-  plans.value.find(p => p.plan_type === activePlan.value)
+  plans.value.find(p => p.planType === activePlan.value)
 )
 
 onMounted(async () => {
 
-    const res = await axios.get('/api/products/')
-    plans.value = res.data.results
+    const res = await axios.get('/payments/products/')
+    plans.value = res.data
 
 })
 </script>


### PR DESCRIPTION
close #166 
MerchantUpgradeModal 串接 後端價格API（ 後端 issue/156）

按月付款：
![Image](https://github.com/user-attachments/assets/921d73d7-6efe-4436-9085-15f7c01ace91)

按年付款：
![Image](https://github.com/user-attachments/assets/a4e9e85e-1d92-47e9-a545-b2865af7ffc5)

皆可按後端設定正常顯示