### PR TITLE
refactor: fetch restaurant details by UUIDs on MyRecentViewedPage

### DIFF
--- a/src/stores/restaurant.js
+++ b/src/stores/restaurant.js
@@ -5,6 +5,7 @@ export const useRestaurantStore = defineStore(
   'restaurant',
   () => {
     const restaurants = ref([]);
+    const recentViewedUuids = ref([]);
     const recentViewedRestaurants = ref([]);
     const dishResult = ref('');
     const userSelections = ref({
@@ -41,13 +42,27 @@ export const useRestaurantStore = defineStore(
       }
     };
 
+
+    const addRecentViewedUuid = (uuid) => {
+      recentViewedUuids.value = recentViewedUuids.value.filter(
+        (id) => id !== uuid
+      );
+      recentViewedUuids.value.unshift(uuid);
+      if (recentViewedUuids.value.length > 12) {
+        recentViewedUuids.value = recentViewedUuids.value.slice(0, 12);
+      }
+    };
+
+
     return {
       restaurants,
       dishResult,
       userSelections,
+      recentViewedUuids,
       recentViewedRestaurants,
       setResults,
       setSelections,
+      addRecentViewedUuid,
       setRecentViewedRestaurant,
     };
   },

--- a/src/views/MyRecentViewedPage.vue
+++ b/src/views/MyRecentViewedPage.vue
@@ -20,9 +20,30 @@ import Navbar from '@/components/Navbar.vue';
 import Footer from '@/components/Footer.vue';
 import RestaurantCard from '@/components/RestaurantCard.vue';
 import { useRestaurantStore } from '@/stores/restaurant';
-import { storeToRefs } from 'pinia';
+import { ref, onMounted } from 'vue';
+import axios from '@/axios';
 
 const store = useRestaurantStore();
-const { recentViewedRestaurants } = storeToRefs(store);
-const restaurants = recentViewedRestaurants;
+const restaurants = ref([]);
+
+onMounted(async () => {
+  const uuids = store.recentViewedUuids;
+
+  if (!uuids || uuids.length === 0) return;
+
+  const params = new URLSearchParams();
+  uuids.forEach((uuid) => {
+    params.append('uuids', uuid);
+  });
+
+  try {
+    const response = await axios.get('/restaurants/recent-viewed/', { params });
+    console.log('取得的餐廳資料：', response.data);
+    restaurants.value = response.data.result || [];
+  } catch (err) {
+    console.error('取得最近瀏覽餐廳失敗', err);
+  }
+});
+
+
 </script>

--- a/src/views/RestaurantDetail.vue
+++ b/src/views/RestaurantDetail.vue
@@ -288,6 +288,8 @@ import ShareButton from '@/components/ShareButton.vue';
 import { useAuthStore } from '../stores/auth';
 import { storeToRefs } from 'pinia';
 import { useAlertStore } from '@/stores/alert';
+import { useRestaurantStore } from '@/stores/restaurant';
+
 
 const alert = useAlertStore();
 
@@ -345,6 +347,12 @@ const couponClaimed = ref(false);
 const displayedReviewsCount = ref(5);
 const mapUrl = ref('');
 const placeId = ref('');
+const store = useRestaurantStore();
+
+onMounted(() => {
+  const restaurantUuid = route.params.id; 
+  store.addRecentViewedUuid(restaurantUuid);
+});
 
 // 餐廳基本信息
 const restaurant = reactive({

--- a/src/views/RestaurantsList.vue
+++ b/src/views/RestaurantsList.vue
@@ -1,12 +1,12 @@
 <template>
   <Navbar></Navbar>
   <div class="bg-white">
-    <div class="flex justify-center items-center mx-auto py-8">
-      <h1 class="text-2xl text-black ml-2">為您推薦</h1>
+    <div class="flex justify-center items-center mx-auto py-5">
+      <h1 class="text-2xl font-bold mb-4">為您推薦</h1>
     </div>
     <section class="px-4 sm:px-0">
       <ul
-        class="mx-6 py-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 place-items-center p-0 list-none"
+        class="mx-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 place-items-center p-0 list-none"
       >
         <li
           v-for="r in topTenRestaurants"
@@ -28,14 +28,14 @@
 import Navbar from '@/components/Navbar.vue';
 import Footer from '@/components/Footer.vue';
 import RestaurantCard from '@/components/RestaurantCard.vue';
-import { ref, onMounted, computed } from 'vue';
+import { computed } from 'vue';
 import { useRestaurantStore } from '@/stores/restaurant';
 
 const store = useRestaurantStore();
 const topTenRestaurants = computed(() => store.restaurants.slice(0, 12));
 
 const handleRecentViewedRestaurant = (r) => {
-  store.setRecentViewedRestaurant(r);
+  store.addRecentViewedUuid(r.uuid);
 };
 </script>
 


### PR DESCRIPTION
* 將「我的最近瀏覽」存取資料方式變更為只存餐廳 uuid  ，然後到該頁面時用 GET 到後端取得詳細且即時的資料
* 原本「我的最近瀏覽」只會記錄從主頁前往的餐廳清單，目前更正為只要造訪餐廳詳細頁面就會顯示
* 擁有優惠券的標示也會顯示在該頁面上

<img width="1440" alt="截圖 2025-06-03 下午4 59 37" src="https://github.com/user-attachments/assets/3c38cf42-97c9-427e-805b-61dfda7009f3" />
<img width="1439" alt="截圖 2025-06-03 下午4 59 56" src="https://github.com/user-attachments/assets/a6ed0529-1427-4739-8ef4-a5e99bd441a4" />
