### PR TITLE
feat(MerchantUpgradeModal): integrate LinePay payment gateway with backend 

### DIFF
--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -117,7 +117,6 @@ const pay = async () => {
     const paymentUrl = res.data.paymentUrlWeb
     window.location.href = paymentUrl
   } catch (err) {
-    console.error('建立訂單失敗：', err)
     alert(err.response?.data?.error || '建立訂單時發生錯誤，請稍後再試')
   } finally {
     isPaying.value = false

--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -44,6 +44,34 @@
         </template>
       </div>
 
+      <!-- 選擇付款方式 -->
+      <div v-if="currentPlan" class="flex gap-3 mb-2">
+        <button
+          class="btn"
+          :class="selectedGateway === 'linepay' ? 'btn-success' : 'btn-outline'"
+          @click="selectedGateway = 'linepay'"
+        >
+          LINEPAY
+        </button>
+        <button
+          disabled
+          class="btn btn-disabled"
+        >
+          綠界支付（未開放）
+        </button>
+      </div>
+
+      <!-- 前往付款 -->
+      <div v-if="currentPlan" class="mb-6">
+        <button
+          class="btn btn-primary w-full"
+          :disabled="!selectedGateway || isPaying"
+          @click="pay"
+        >
+          前往付款
+        </button>
+      </div>
+      
       <!-- 關閉按鈕 -->
       <div class="mt-6 text-right">
         <button class="btn btn-sm" @click="$emit('close')">關閉</button>

--- a/src/components/MerchantUpgradeModal.vue
+++ b/src/components/MerchantUpgradeModal.vue
@@ -71,7 +71,7 @@
           前往付款
         </button>
       </div>
-      
+
       <!-- 關閉按鈕 -->
       <div class="mt-6 text-right">
         <button class="btn btn-sm" @click="$emit('close')">關閉</button>
@@ -95,6 +95,34 @@ const plans = ref([])
 const currentPlan = computed(() =>
   plans.value.find(p => p.planType === activePlan.value)
 )
+
+const selectedGateway = ref(null) // 使用者選擇的付款方式（linepay / ecpay）
+const isPaying = ref(false) // 防止重複送出
+
+const pay = async () => {
+  if (!currentPlan.value || !selectedGateway.value) return
+
+  if (selectedGateway.value !== 'linepay') {
+    alert('目前僅支援 LINEPAY，綠界尚未開放')
+    return
+  }
+
+  try {
+    isPaying.value = true
+    const res = await axios.post('/payments/linepay/subscribe/', {
+      product_id: currentPlan.value.uuid,
+      amount: currentPlan.value.amount
+    })
+
+    const paymentUrl = res.data.paymentUrlWeb
+    window.location.href = paymentUrl
+  } catch (err) {
+    console.error('建立訂單失敗：', err)
+    alert(err.response?.data?.error || '建立訂單時發生錯誤，請稍後再試')
+  } finally {
+    isPaying.value = false
+  }
+}
 
 onMounted(async () => {
 


### PR DESCRIPTION
closes #174 

升級VIP的Modal 
串接後端LinePay付款與付款頁面

可正常跳轉支付頁面，操作影片：
https://github.com/user-attachments/assets/f0def804-63f6-4331-b48e-340ec81530de


支付完成以後，店家有正確升級VIP，操作影片：
https://github.com/user-attachments/assets/5085e2dd-82e9-48e2-b849-338aef912c4e



後續確認：
付款完成後跳轉頁面