### PR TITLE
feat: add redirect after successful LinePay payment

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -99,6 +99,11 @@ const routes = [
     component: () => import('../views/PromotionDetail.vue'),
     meta: { requiresAuth: true, requiresMerchant: true },
   },
+  {
+    path: '/payments/success',
+    name: 'PaymentSuccess',
+    component: () => import('@/views/PaymentSuccess.vue'),
+  },
 ];
 
 const router = createRouter({

--- a/src/views/PaymentSuccess.vue
+++ b/src/views/PaymentSuccess.vue
@@ -1,4 +1,4 @@
-<template>Add commentMore actions
+<template>
   <div class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
     <div class="max-w-md w-full bg-white rounded-2xl shadow-xl p-6 text-center">
       <div v-if="isLoading" class="animate-pulse text-gray-500">

--- a/src/views/PaymentSuccess.vue
+++ b/src/views/PaymentSuccess.vue
@@ -50,9 +50,6 @@ onMounted(async () => {
 
   try {
     const res = await axios.get(`/payments/order/${orderId}/`)
-    console.log('接收到的 orderId：', route.query.orderId)
-    console.log('實際打出去的 API：', axios.defaults.baseURL + `/payments/order/${orderId}/`)
-
     orderData.value = res.data.result
     isSuccess.value = true
   } catch (err) {

--- a/src/views/PaymentSuccess.vue
+++ b/src/views/PaymentSuccess.vue
@@ -27,7 +27,7 @@
   </div>
 </template>
 
-<script setup>Add commentMore actions
+<script setup>
 import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from '@/axios'

--- a/src/views/PaymentSuccess.vue
+++ b/src/views/PaymentSuccess.vue
@@ -26,3 +26,43 @@
     </div>
   </div>
 </template>
+
+<script setup>Add commentMore actions
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import axios from '@/axios'
+
+const route = useRoute()
+const router = useRouter()
+
+const isLoading = ref(true)
+const isSuccess = ref(false)
+const errorMsg = ref('')
+const orderData = ref(null)
+
+onMounted(async () => {
+  const orderId = route.query.orderId
+  if (!orderId) {
+    errorMsg.value = '找不到訂單資訊，請確認付款是否成功。'
+    isLoading.value = false
+    return
+  }
+
+  try {
+    const res = await axios.get(`/payments/order/${orderId}/`)
+    console.log('接收到的 orderId：', route.query.orderId)
+    console.log('實際打出去的 API：', axios.defaults.baseURL + `/payments/order/${orderId}/`)
+
+    orderData.value = res.data.result
+    isSuccess.value = true
+  } catch (err) {
+    errorMsg.value = '查詢訂單資訊失敗，請聯絡客服。'
+  } finally {
+    isLoading.value = false
+  }
+})
+
+const goHome = () => {
+  router.push({ name: 'MerchantDashboard' })
+}
+</script>

--- a/src/views/PaymentSuccess.vue
+++ b/src/views/PaymentSuccess.vue
@@ -1,0 +1,28 @@
+<template>Add commentMore actions
+  <div class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+    <div class="max-w-md w-full bg-white rounded-2xl shadow-xl p-6 text-center">
+      <div v-if="isLoading" class="animate-pulse text-gray-500">
+        載入付款資訊中...
+      </div>
+
+      <div v-else-if="isSuccess && orderData">
+        <h2 class="text-2xl font-bold text-green-600 mb-2">付款成功 🎉</h2>
+        <p class="text-gray-700">感謝您升級為 VIP 商家！</p>
+        <div class="mt-4 text-sm text-gray-600">
+          訂單編號：<span class="font-mono">{{ orderData.orderId }}</span>
+        </div>
+        <button
+          @click="goHome"
+          class="mt-6 bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg shadow transition"
+        >
+          返回首頁
+        </button>
+      </div>
+
+      <div v-else class="text-red-600">
+        <h2 class="text-xl font-bold mb-2">付款資訊異常</h2>
+        <p>{{ errorMsg }}</p>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
close #190 
（需與後端PR過了才會生效）


**新增LinePay付款成功以後跳轉頁面**

https://github.com/user-attachments/assets/beecf6dc-e88b-4485-8804-0774cacd5191

**- Line Pay 付款頁面**
![Image](https://github.com/user-attachments/assets/805b1c4a-2fac-4bf0-aa7a-7e5f7b6e6c97)


**- 付款後跳轉頁面（確認訂單狀態）：**
![Image](https://github.com/user-attachments/assets/a3baa12f-708c-4f3d-8b54-77eab488aec4)

**- 付款成功頁面（確認完成付款，點擊回首頁可回到DashBoard）**
![Image](https://github.com/user-attachments/assets/f1cc9c2c-936a-45fc-b7b8-ce44a02353be)