### PR TITLE
style: refine layout of RestaurantDetail page

### DIFF
--- a/src/components/AddReview.vue
+++ b/src/components/AddReview.vue
@@ -1,6 +1,6 @@
 <template>
-    <div v-if="show" class="modal-overlay" @click.self="closeModal">
-      <div class="modal-container">
+    <div v-if="show" class="modal-overlay max-w-screen-lg mx-auto" @click.self="closeModal">
+      <div class="modal-container ">
         <!-- 使用者頭像與名稱 -->
         <div class="user-info">
           <img :src="userAvatar" alt="頭像" class="avatar border border-black" />

--- a/src/components/AddReview.vue
+++ b/src/components/AddReview.vue
@@ -1,169 +1,176 @@
 <template>
-    <div v-if="show" class="modal-overlay max-w-screen-lg mx-auto" @click.self="closeModal">
-      <div class="modal-container ">
-        <!-- 使用者頭像與名稱 -->
-        <div class="user-info">
-          <img :src="userAvatar" alt="頭像" class="avatar border border-black" />
-          <span class="username text-black">{{ userName }}</span>
-        </div>
-  
-        <!-- 星星評分 -->
-        <div class="rating">
+  <div v-if="show" class="fixed top-0 left-0 w-full h-full bg-black/60 flex justify-center items-center z-50 backdrop-blur-sm" @click.self="closeModal">
+    <div class="bg-white p-6 rounded-xl w-[90%] max-w-md max-h-[90vh] overflow-y-auto shadow-2xl mx-4">
+      <!-- 使用者頭像與名稱 -->
+      <div class="flex items-center gap-3 mb-5 pb-4 border-b border-gray-200">
+        <img :src="userAvatar" alt="頭像" class="w-12 h-12 rounded-full border-2 border-gray-300 object-cover" />
+        <span class="font-semibold text-gray-800 text-sm md:text-lg">{{ userName }}</span>
+      </div>
+
+      <!-- 星星評分 -->
+      <div class="mb-5">
+        <div class="font-medium text-gray-800 mb-2 text-sm md:text-lg">評分</div>
+        <div class="flex gap-1 mb-2">
           <span 
             v-for="star in 5" 
             :key="star" 
             @click="setRating(star)" 
-            :class="['star', { active: star <= rating }]"
+            @mouseover="hoverRating = star"
+            @mouseleave="hoverRating = 0"
+            :class="[
+              'text-3xl cursor-pointer select-none transition-all duration-200 hover:scale-110',
+              (star <= rating) ? 'text-yellow-400' : 
+              (star <= hoverRating && hoverRating > 0) ? 'text-yellow-300' : 'text-gray-300'
+            ]"
           >
             ★
           </span>
         </div>
 
-  
-  
-        <!-- 評論區 -->
+      </div>
+
+      <!-- 評論區 -->
+      <div class="mb-5">
+        <label class="block font-medium text-gray-800 mb-2 text-sm md:text-lg">評論內容</label>
         <textarea 
           v-model="content" 
-          placeholder="請輸入評論..." 
-          class="review-textarea placeholder-gray-300 px-2 py-1 text-s text-black"
+          placeholder="請輸入您的評論..." 
+          class="w-full px-3 border-2 border-gray-200 rounded-lg resize-none focus:outline-none focus:border-neutral transition-colors duration-200 text-sm leading-relaxed"
+          rows="4"
         ></textarea>
-  
-    
-        <div v-if="image" class="image-preview">
-                    <img :src="image" alt="預覽圖片" />
-        </div>
-      
-        <div class="flex flex-col items-center mx-auto gap-2">
-            <label class="text-black border border-black text-center w-full py-1 rounded-full cursor-pointer" >
-                上傳相片
-                <input type="file" @change="handleFileUpload" hidden/>
-                
-            </label>
-            <button @click="submitReview" class="border bg-black text-white w-full text-center py-1 rounded-full cursor-pointer">送出評論</button>
+      </div>
+
+      <!-- 圖片預覽 -->
+      <div v-if="image" class="relative mb-5">
+        <img :src="image" alt="預覽圖片" class="w-full max-h-48 object-cover rounded-lg border border-gray-200" />
+        <button 
+          @click="removeImage" 
+          class="absolute top-2 right-2 w-6 h-6 rounded-full bg-neutral bg-opacity-60 text-white flex items-center justify-center text-base font-bold hover:bg-opacity-80 transition-all duration-200"
+        >
+          ×
+        </button>
+      </div>
+
+      <!-- 操作按鈕 -->
+      <div class="flex flex-col gap-2">
+        <label class="flex items-center justify-center gap-2 p-2 border-2  border-neutral rounded-xl cursor-pointer hover:primary   transition-all duration-200  text-neutral text-sm md:text-base">
           
-        </div>
+          上傳相片
+          <input type="file" @change="handleFileUpload" accept="image/*" class="hidden"/>
+        </label>
+        <button 
+          @click="submitReview" 
+          :disabled="!canSubmit"
+          :class="[
+            'w-full p-2 rounded-xl text-sm transition-all duration-200 md:text-base bg-neutral',
+            canSubmit 
+              ? 'bg-neutral text-white hover:bg-primary hover:-translate-y-0.5 shadow-lg hover:shadow-xl' 
+              : 'bg-gray-300 text-white cursor-not-allowed'
+          ]"
+        >
+          送出評論
+        </button>
       </div>
     </div>
-  </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { useAlertStore } from '@/stores/alert';
+import { onUnmounted } from 'vue';
+
+
+const props = defineProps({
+  show: Boolean,
+  userName: String,
+  userAvatar: String,
+});
+
+const emit = defineEmits(['close', 'submit']);
+
+const content = ref('');
+const rating = ref(0);
+const hoverRating = ref(0);
+const image = ref(null);
+const file = ref(null);
+const alert = useAlertStore();
+
+// 計算是否可以提交
+const canSubmit = computed(() => {
+  return content.value.trim().length > 0 && rating.value > 0;
+});
+
+// 關閉 Modal
+const closeModal = () => {
+  emit('close');
+};
+
+// 設定評分
+const setRating = (star) => {
+  rating.value = star;
+};
+
+
+
+// 圖片上傳處理
+const handleFileUpload = (event) => {
+  const uploadedFile = event.target.files[0];
+  if (uploadedFile) {
+    // 檢查檔案大小 (限制 5MB)
+    if (uploadedFile.size > 1 * 1024 * 1024) {
+      alert.trigger('檔案大小不能超過 1 MB，請重新再試', 'error');
+      return;
+    }
+    
+    file.value = uploadedFile;
+    image.value = URL.createObjectURL(uploadedFile);
+  }
+};
+
+// 移除圖片
+const removeImage = () => {
+  if (image.value) {
+    URL.revokeObjectURL(image.value);
+  }
+  image.value = null;
+  file.value = null;
+};
+
+// 送出評論
+const submitReview = () => {
+  if (!canSubmit.value) return;
   
-  <script setup>
-  import { ref } from 'vue';
- 
-  
-  const props = defineProps({
-    show: Boolean,
-    userName: String,
-    userAvatar: String,
+  emit('submit', {
+    content: content.value.trim(),
+    rating: rating.value,
+    imageFile: file.value,
   });
   
-  const emit = defineEmits(['close', 'submit']);
-  
+  // 重置表單
+  content.value = '';
+  rating.value = 0;
+  hoverRating.value = 0;
+  removeImage();
+  closeModal();
+};
 
-  const content = ref('');
-  const rating = ref(0);
-  const image = ref(null);
-  const file = ref(null);
-  
-  // 關閉 Modal
-  const closeModal = () => {
-    emit('close');
-  };
-  
-  // 設定評分
-  const setRating = (star) => {
-    rating.value = star;
-  };
-  
-  // 圖片上傳處理
-  const handleFileUpload = (event) => {
-    const uploadedFile = event.target.files[0];
-    if (uploadedFile) {
-      file.value = uploadedFile;
-      image.value = URL.createObjectURL(uploadedFile);
-    }
-  };
-  
-  // 送出評論
-  const submitReview = () => {
-    if (content.value.trim()) {
-      emit('submit', {
-        content: content.value.trim(),
-        rating: rating.value,
-        imageFile: file.value,
-      });
-      content.value = '';
-      rating.value = 0;
-      image.value = null;
-      file.value = null;
-      closeModal();
-    }
-  };
-  </script>
-  
-  <style scoped>
-  .modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.6);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 999;
-  }
-  
-  .modal-container {
-    background-color: #fff;
-    padding: 20px;
-    border-radius: 8px;
-    width: 80%;
-    max-width: 400px;
-  }
-  
-  .user-info {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 10px;
-  }
-  
-  .avatar {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-  }
-  
-  .rating {
-    display: flex;
-    gap: 5px;
-  }
-  
-  .star {
-    font-size: 24px;
-    cursor: pointer;
-    color: gray;
-  }
-  
-  .star.active {
-    color: #ff0000;
-    font-weight: bold;
-  }
-  
-.review-textarea {
-    width: 100%;
-    height: 100px;
-    margin: 10px 0;
-    border: 1px solid black;
-    border-radius: 5px;
-  }
-  
-  .image-preview img {
-    max-width: 100%;
-    margin: 10px 0;
-  }
-  
 
-  </style>
-  
+const cleanup = () => {
+  if (image.value) {
+    URL.revokeObjectURL(image.value);
+  }
+};
+
+onUnmounted(cleanup);
+</script>
+
+<style scoped>
+
+@media (max-width: 480px) {
+  .bg-white {
+    width: 95%;
+    padding: 1.25rem;
+  }
+}
+</style>

--- a/src/components/CouponCarousel.vue
+++ b/src/components/CouponCarousel.vue
@@ -5,28 +5,17 @@
       class="flex transition-transform duration-500"
       :style="`transform: translateX(-${currentIndex * 100}%);`"
     >
+      
       <div
         v-for="(coupon, index) in coupons"
         :key="coupon.uuid"
         class="w-full flex-shrink-0 mt-4 "
       >
         <div class="bg-gray-100 rounded-lg p-4">
-          <button
-            @click="claimCoupon(coupon.uuid)"
-            :class="[
-              'btn w-full rounded-lg mb-2 border transition-colors duration-300 text-base md:text-lg',
-              claimedLocal[coupon.uuid]
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed text-base md:text-lg'
-                : 'bg-primary text-white hover:neutral text-base md:text-lg',
-            ]"
-            :disabled="claimedLocal[coupon.uuid]"
-          >
-            <font-awesome-icon :icon="['fas', 'ticket-alt']" class="mr-2 " />
-            {{ claimedLocal[coupon.uuid] ? '已領取' : '領取優惠券' }}
-          </button>
+         
 
           <!-- 詳細內容 -->
-          
+          <h4 class="text-base md:text-xl font-bold mb-2">優惠券詳細資訊</h4>
           <div class="space-y-2 text-sm">
             <div>
               <span class="text-gray-500 text-base md:text-lg">標題：</span>
@@ -47,21 +36,32 @@
             </div>
             <div v-if="coupon.description">
               <span class="text-gray-500 text-base md:text-lg">使用說明：</span>
-              <p class="text-gray-700 text-base md:text-lg">{{ coupon.description }}</p>
+              <p class="text-gray-700 text-base md:text-lg mb-4">{{ coupon.description }}</p>
             </div>
           </div>
 
-          <div class="mt-3 text-base md:text-lg text-gray-500 ">
-            <span v-if="claimedLocal[coupon.uuid]">已領取</span>
-            <span v-else>尚未領取</span>
-          </div>
+         
+          <button
+            @click="claimCoupon(coupon.uuid)"
+            :class="[
+              'btn w-full rounded-lg mb-2 border transition-colors duration-300 text-base md:text-lg cursor-pointer ',
+              claimedLocal[coupon.uuid]
+                ? 'bg-gray-300 text-gray-500 cursor-not-allowed text-base md:text-lg'
+                : 'bg-primary text-white hover:bg-neutral text-base md:text-lg',
+            ]"
+            :disabled="claimedLocal[coupon.uuid]"
+          >
+            <font-awesome-icon :icon="['fas', 'ticket-alt']" class="mr-2 " />
+            {{ claimedLocal[coupon.uuid] ? '已領取' : '領取優惠券' }}
+          </button>
+
         </div>
       </div>
     </div>
   </div>
 
   <!-- 點點控制器 -->
-  <div v-if="coupons.length > 1" class="flex justify-center mt-3 space-x-2">
+  <div v-if="coupons.length > 1" class="flex justify-center mt-3 space-x-2 ">
     <button
       v-for="(dot, index) in coupons.length"
       :key="index"

--- a/src/components/CouponCarousel.vue
+++ b/src/components/CouponCarousel.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- 外層限制輪播寬度與 overflow -->
-  <div class="overflow-hidden w-full">
+  <div class="overflow-hidden">
     <div
       class="flex transition-transform duration-500"
       :style="`transform: translateX(-${currentIndex * 100}%);`"
@@ -8,50 +8,50 @@
       <div
         v-for="(coupon, index) in coupons"
         :key="coupon.uuid"
-        class="w-full flex-shrink-0 p-4"
+        class="w-full flex-shrink-0 mt-4 "
       >
-        <div class="bg-gray-50 rounded-lg p-4">
+        <div class="bg-gray-100 rounded-lg p-4">
           <button
             @click="claimCoupon(coupon.uuid)"
             :class="[
-              'btn w-full rounded-lg mb-2 border transition-colors duration-300',
+              'btn w-full rounded-lg mb-2 border transition-colors duration-300 text-base md:text-lg',
               claimedLocal[coupon.uuid]
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                : 'bg-orange-500 text-white hover:bg-orange-600',
+                ? 'bg-gray-300 text-gray-500 cursor-not-allowed text-base md:text-lg'
+                : 'bg-primary text-white hover:neutral text-base md:text-lg',
             ]"
             :disabled="claimedLocal[coupon.uuid]"
           >
-            <font-awesome-icon :icon="['fas', 'ticket-alt']" class="mr-2" />
+            <font-awesome-icon :icon="['fas', 'ticket-alt']" class="mr-2 " />
             {{ claimedLocal[coupon.uuid] ? '已領取' : '領取優惠券' }}
           </button>
 
           <!-- 詳細內容 -->
-          <h4 class="text-sm font-bold mb-2">優惠券詳細資訊</h4>
+          
           <div class="space-y-2 text-sm">
             <div>
-              <span class="text-gray-500">標題：</span>
-              <span class="font-medium">{{ coupon.title }}</span>
+              <span class="text-gray-500 text-base md:text-lg">標題：</span>
+              <span class="font-medium text-base md:text-lg">{{ coupon.title }}</span>
             </div>
             <div>
-              <span class="text-gray-500">折扣：</span>
-              <span class="font-medium text-red-500">{{
+              <span class="text-gray-500 text-base md:text-lg">折扣：</span>
+              <span class="font-medium text-red-500 text-base md:text-lg">{{
                 coupon.discount
               }}</span>
             </div>
             <div>
-              <span class="text-gray-500">期間：</span>
-              <span class="font-medium">
+              <span class="text-gray-500 text-base md:text-lg">期間：</span>
+              <span class="font-medium text-base md:text-lg">
                 {{ formatDate(coupon.startedAt) }} ~
                 {{ formatDate(coupon.endedAt) }}
               </span>
             </div>
             <div v-if="coupon.description">
-              <span class="text-gray-500">使用說明：</span>
-              <p class="text-gray-700">{{ coupon.description }}</p>
+              <span class="text-gray-500 text-base md:text-lg">使用說明：</span>
+              <p class="text-gray-700 text-base md:text-lg">{{ coupon.description }}</p>
             </div>
           </div>
 
-          <div class="mt-3 text-xs text-gray-500">
+          <div class="mt-3 text-base md:text-lg text-gray-500 ">
             <span v-if="claimedLocal[coupon.uuid]">已領取</span>
             <span v-else>尚未領取</span>
           </div>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,8 +1,8 @@
 <template>
   <footer class="bg-[#573921] text-white py-12 px-8">
-    <div class="max-w-6xl mx-auto">
+    <div class="max-w-screen-lg mx-auto">
       <!-- 主要內容區域 -->
-      <div class="grid grid-rows-1 md:grid-cols-4 gap-8 mb-8">
+      <div class="grid grid-rows-1 md:grid-cols-4 gap-8 mb-8 ">
         
         <!-- Logo 和聯絡資訊 -->
         <div class="row-span-1">

--- a/src/components/GoogleMapEmbed.vue
+++ b/src/components/GoogleMapEmbed.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="map-container">
-    <div class="map-frame-wrapper">
+  
+    <div class="w-full  max-w-full">
       <iframe
         :src="mapUrl"
         :width="mapWidth"
@@ -11,7 +11,7 @@
         referrerpolicy="no-referrer-when-downgrade"
       ></iframe>
     </div>
-  </div>
+
 </template>
 
 <script setup>
@@ -35,10 +35,4 @@ const props = defineProps({
 });
 </script>
 
-<style scoped>
-.map-frame-wrapper iframe {
-  width: 100%;
-  height: 200px;
-  max-width: 100%;
-}
-</style>
+

--- a/src/components/PromotionCarousel.vue
+++ b/src/components/PromotionCarousel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-if="promotions.length > 0" class="relative w-full overflow-hidden">
-    <h3 class="text-base font-bold mb-3 px-4">最新動態</h3>
+  <div v-if="promotions.length > 0" class="relative overflow-hidden max-w-screen-lg mx-auto">
+    <h3 class="text-base md:text-2xl font-bold  px-4">最新動態</h3>
     <div
       class="flex transition-transform duration-500"
       :style="`transform: translateX(-${currentIndex * 100}%);`"
@@ -10,7 +10,7 @@
         :key="index"
         class="w-full flex-shrink-0 p-4"
       >
-        <div class="bg-white shadow rounded-lg overflow-hidden">
+        <div class="bg-white rounded-lg overflow-hidden shadow-[0_0_10px_rgba(0,0,0,0.15)] ">
           <img
             v-if="promotion.imageUrl"
             :src="promotion.imageUrl"
@@ -18,11 +18,11 @@
             :alt="promotion.title"
           />
           <div class="p-4">
-            <h3 class="text-base font-bold mb-1">{{ promotion.title }}</h3>
-            <p class="text-sm text-gray-700 mb-1">
+            <h3 class="text-base font-bold mb-1 md:text-xl">{{ promotion.title }}</h3>
+            <p class="text-base text-gray-700 mb-1 md:text-lg">
               {{ promotion.description }}
             </p>
-            <p class="text-xs text-gray-500">
+            <p class="text-base text-gray-500 md:text-lg">
               活動期間：{{ formatDate(promotion.startedAt) }} ~
               {{ formatDate(promotion.endedAt) }}
             </p>

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -1,9 +1,9 @@
 <template>
   <!-- 分享按鈕 -->
-  <button @click="toggleShareModal" class="btn btn-circle">
+  <button @click="toggleShareModal" class="btn rounded-xl bg-gray-200 ">
     <font-awesome-icon
-      :icon="['fas', 'share-alt']"
-      class="text-gray-600 text-xl"
+      :icon="['fas', 'arrow-up-right-from-square']"
+      class="text-[rgb(87,57,33)]' text-sm md:text-xl text-gray-400"
     />
   </button>
 
@@ -15,8 +15,8 @@
   >
     <div class="bg-white rounded-lg p-6 m-4 max-w-sm w-full" @click.stop>
       <div class="flex justify-between items-center mb-4">
-        <h3 class="text-lg font-bold">分享餐廳</h3>
-        <button @click="closeShareModal" class="text-gray-500 hover:text-gray-700">
+        <h3 class="text-lg md:text-2xl font-bold mx-auto">分享餐廳</h3>
+        <button @click="closeShareModal" class="text-[rgb(87,57,33)]' hover:text-gray-700 ">
           <font-awesome-icon :icon="['fas', 'times']" class="text-xl" />
         </button>
       </div>
@@ -49,10 +49,10 @@
           @click="shareToTwitter" 
           class="flex flex-col items-center p-3 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
         >
-          <div class="w-12 h-12 bg-blue-400 rounded-full flex items-center justify-center mb-2">
-            <font-awesome-icon :icon="['fab', 'twitter']" class="text-white text-xl" />
+          <div class="w-12 h-12 bg-black rounded-full flex items-center justify-center mb-2">
+            <font-awesome-icon :icon="['fab', 'x-twitter']" class="text-white text-xl" />
           </div>
-          <span class="text-xs text-gray-700">Twitter</span>
+          <span class="text-xs text-gray-700">X</span>
         </button>
         
         <!-- 複製連結 -->

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -10,7 +10,7 @@
   <!-- 分享彈窗 -->
   <div 
     v-if="showShareModal" 
-    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" 
+    class="fixed inset-0 bg-black/80 flex items-center justify-center z-50" 
     @click="closeShareModal"
   >
     <div class="bg-white rounded-lg p-6 m-4 max-w-sm w-full" @click.stop>

--- a/src/views/RestaurantDetail.vue
+++ b/src/views/RestaurantDetail.vue
@@ -24,7 +24,7 @@
     <!-- 餐廳名稱與操作按鈕 -->
     <div class="flex flex-col md:flex-row items-start md:items-center justify-start md:justify-between mb-1 max-w-screen-lg mx-auto px-4">
       <div class="flex items-center">
-        <h1 class="text-xl md:text-4xl font-bold md:mt-6 truncate max-w-[14em] md:truncate-none md:max-w-none mb-2">{{ restaurant.name }}</h1>
+        <h1 class="text-xl md:text-4xl font-bold md:mt-4 truncate max-w-[14em] md:truncate-none md:max-w-none mb-2">{{ restaurant.name }}</h1>
       </div>
       <div class="flex md:space-x-2 space-x-1.5">
         <ShareButton
@@ -35,13 +35,13 @@
           <font-awesome-icon
             :icon="[isFavorite ? 'fas' : 'far', 'heart']"
             :class="isFavorite ? 'text-red-500' : 'text-gray-400'"
-            class="text-sm md:text-xl "
+            class="text-lg md:text-2xl "
           />
         </button>
         <button @click="navigateToAddress" class="btn rounded-xl bg-primary">
           <font-awesome-icon
             :icon="['fas', 'location-arrow']"
-            class="text-sm md:text-xl text-white"
+            class="text-lg md:text-2xl text-white"
           />
         </button>
       </div>
@@ -111,7 +111,7 @@
 
     <!-- 優惠券輪播 -->
     <div class="mb-6 px-4 max-w-screen-lg mx-auto mt-6">
-      <h4 class="text-base md:text-2xl font-bold">優惠券詳細資訊</h4>
+      
 
         <CouponCarousel
           v-if="coupons.length"
@@ -143,7 +143,7 @@
         <button
           :disabled="hasReviewed"
           @click="handleAddReviewClick"
-          class="btn btn-sm md:btn-md border border-gray-400 text-gray-400 rounded-xl px-2 md:px-6 cursor-pointer hover:bg-gray-100 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm md:text-base py-2 md:mt-6"
+          class="btn btn-sm md:btn-md border bg-gray-100 border-gray-200 text-gray-500 rounded-xl px-2 md:px-6 cursor-pointer hover:bg-gray-300 hover:text-white transition disabled:opacity-50 disabled:cursor-not-allowed text-sm md:text-base py-2 md:mt-6"
         >
           {{ hasReviewed ? '已評論' : '＋ 新增評論' }}
         </button>

--- a/src/views/RestaurantDetail.vue
+++ b/src/views/RestaurantDetail.vue
@@ -1,62 +1,72 @@
 <template>
   <Navbar class="w-full" />
-  <div class="w-full px-2">
+  <div class="w-full  pt-20">
     <!-- 餐廳主圖片 -->
-    <div class="w-full h-64 bg-gray-200 overflow-hidden mb-4">
-      <img
-        :src="restaurant.imageUrl || 'https://picsum.photos/1200/400'"
-        :alt="restaurant.name"
-        class="w-full h-full object-cover"
-      />
-    </div>
+    <div class="relative w-full overflow-hidden mb-4">
+  <!-- 背景模糊圖（僅限 md 以上顯示） -->
+  <img
+    :src="restaurant.imageUrl || 'https://picsum.photos/1200/400'"
+    class="hidden md:block absolute inset-0 w-full h-full object-cover blur-sm scale-110 opacity-60"
+    alt="模糊背景"
+  />
+
+  <!-- 前景主圖片 -->
+  <div class="relative z-10  flex justify-center">
+    <img
+      :src="restaurant.imageUrl || 'https://picsum.photos/1200/400'"
+      :alt="restaurant.name"
+      class="w-full  md:max-w-screen-md h-auto max-h-[300px] md:max-h-[540px] object-cover shadow-lg"
+    />
+  </div>
+</div>
+
 
     <!-- 餐廳名稱與操作按鈕 -->
-    <div class="flex justify-between items-center mb-1">
+    <div class="flex flex-col md:flex-row items-start md:items-center justify-start md:justify-between mb-1 max-w-screen-lg mx-auto px-4">
       <div class="flex items-center">
-        <font-awesome-icon :icon="['fas', 'home']" class="text-blue-500 mr-2" />
-        <h1 class="text-xl font-bold">{{ restaurant.name }}</h1>
+        <h1 class="text-xl md:text-4xl font-bold md:mt-6 truncate max-w-[14em] md:truncate-none md:max-w-none mb-2">{{ restaurant.name }}</h1>
       </div>
-      <div class="flex space-x-2">
+      <div class="flex md:space-x-2 space-x-1.5">
         <ShareButton
           :restaurant-name="restaurant.name"
           :restaurant-rating="restaurant.googleRating || '4.5'"
         />
-        <button @click="toggleFavorite" class="btn btn-circle">
+        <button @click="toggleFavorite" class="btn rounded-xl bg-gray-200">
           <font-awesome-icon
             :icon="[isFavorite ? 'fas' : 'far', 'heart']"
-            :class="isFavorite ? 'text-red-500' : 'text-gray-500'"
-            class="text-2xl"
+            :class="isFavorite ? 'text-red-500' : 'text-gray-400'"
+            class="text-sm md:text-xl "
           />
         </button>
-        <button @click="navigateToAddress" class="btn btn-circle">
+        <button @click="navigateToAddress" class="btn rounded-xl bg-primary">
           <font-awesome-icon
             :icon="['fas', 'location-arrow']"
-            class="text-3xl"
+            class="text-sm md:text-xl text-white"
           />
         </button>
       </div>
     </div>
 
     <!-- 評分與地址 -->
-    <div class="flex items-center mb-1">
+    <div class="flex items-center mb-1 max-w-screen-lg mx-auto px-4">
       <font-awesome-icon :icon="['fas', 'star']" class="text-yellow-400" />
-      <span class="ml-2 text-sm text-gray-600">{{
+      <span class="ml-2 text-sm md:text-xl my-2 text-gray-600">{{
         restaurant.googleRating
       }}</span>
-      <span class="ml-1 text-xs text-gray-500"
+      <span class="ml-2 text-xs text-gray-500 md:text-xl my-2"
         >({{ restaurant.userRatingsTotal }})</span
       >
     </div>
-    <div class="flex items-start mb-4">
+    <div class="flex items-start mb-4 max-w-screen-lg mx-auto px-4">
       <font-awesome-icon
         :icon="['fas', 'map-marker-alt']"
-        class="text-gray-500 mt-0.5 mr-2"
+        class="text-gray-500 md:text-xl my-2"
       />
-      <span class="text-sm text-gray-700">{{ restaurant.address }}</span>
+      <span class="ml-2 text-sm text-gray-700 md:text-xl my-2">{{ restaurant.address }}</span>
     </div>
 
     <!-- 地圖區塊 -->
-    <div class="w-full h-48 bg-gray-200 overflow-hidden mb-4">
+    <div class="w-full h-48 overflow-hidden mb-4 max-w-screen-lg mx-auto px-4">
       <GoogleMapEmbed
         :mapUrl="mapUrl"
         alt="地圖"
@@ -65,13 +75,14 @@
     </div>
 
     <!-- 營業時間 -->
-    <div class="mb-6">
-      <h3 class="text-base font-bold mb-3">營業時間</h3>
+    <div class="mb-6 px-4 max-w-screen-lg mx-auto">
+
+      <h3 class="text-base md:text-2xl font-bold mb-3 md:mt-10">營業時間</h3>
       <div class="space-y-1 text-sm">
         <div
           v-for="(hours, day) in formattedOpenHours"
           :key="day"
-          class="flex justify-between"
+          class="flex justify-between text-base md:text-lg "
         >
           <span
             :class="[
@@ -95,15 +106,23 @@
           >
         </div>
       </div>
+      
     </div>
 
     <!-- 優惠券輪播 -->
-    <CouponCarousel
-      v-if="coupons.length"
-      :coupons="coupons"
-      :claimedStatus="claimedStatus"
-      class="mb-6"
-    />
+    <div class="mb-6 px-4 max-w-screen-lg mx-auto mt-6">
+      <h4 class="text-base md:text-2xl font-bold">優惠券詳細資訊</h4>
+
+        <CouponCarousel
+          v-if="coupons.length"
+          :coupons="coupons"
+          :claimedStatus="claimedStatus"
+          class="mb-6 "
+        />
+
+    </div>
+
+   
 
     <!-- 最新動態輪播 -->
     <PromotionCarousel
@@ -113,25 +132,25 @@
     />
 
     <!-- 評論區塊 -->
-    <div class="mb-6">
-      <div class="flex justify-between items-center mb-3">
-        <h3 class="text-base font-bold">
+    <div class="mb-6 max-w-screen-lg  mx-auto">
+      <div class="flex justify-between items-center mb-3 max-w-screen-lg mx-auto px-4">
+        <h3 class="text-base font-bold md:text-2xl md:mt-6">
           評論
-          <span class="text-sm text-gray-500 font-normal"
-            >(共 {{ reviews.length }} 則)</span
+          <span class="text-sm text-gray-500 font-normal md:text-lg"
+            >（ 共 {{ reviews.length }} 則 ）</span
           >
         </h3>
         <button
           :disabled="hasReviewed"
           @click="handleAddReviewClick"
-          class="btn btn-sm border border-gray-400 text-gray-600 rounded-3xl px-6 cursor-pointer hover:bg-gray-100 transition disabled:opacity-50 disabled:cursor-not-allowed"
+          class="btn btn-sm md:btn-md border border-gray-400 text-gray-400 rounded-xl px-2 md:px-6 cursor-pointer hover:bg-gray-100 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm md:text-base py-2 md:mt-6"
         >
-          {{ hasReviewed ? '已評論' : '＋ 新增' }}
+          {{ hasReviewed ? '已評論' : '＋ 新增評論' }}
         </button>
       </div>
 
-      <div class="space-y-3">
-        <div v-if="reviews.length === 0" class="text-center py-8 text-gray-500">
+      <div class="space-y-3 ">
+        <div v-if="reviews.length === 0" class="text-center py-8 text-gray-500 text-base md:text-xl">
           暫無評論
         </div>
         <ReviewModal
@@ -145,7 +164,7 @@
         <div
           v-for="(review, index) in displayedReviews"
           :key="index"
-          class="bg-gray-100 rounded-lg p-4"
+          class="bg-gray-100 rounded-lg max-w-screen-lg mx-4 p-4"
         >
           <div class="flex items-start">
             <div class="avatar">
@@ -160,7 +179,7 @@
             </div>
             <div class="ml-3 flex-1">
               <div class="flex flex-col items-left mb-1">
-                <h4 class="font-semibold text-sm text-black">
+                <h4 class="font-semibold text-base md:text-xl text-black">
                   {{ review.user.userName }}
                 </h4>
                 <div class="flex items-center">
@@ -168,12 +187,12 @@
                     :icon="['fas', 'star']"
                     class="text-yellow-400 text-xs"
                   />
-                  <span class="ml-1 text-xs text-gray-600">{{
+                  <span class="ml-1  text-gray-600 text-sm md:text-lg">{{
                     review.rating
                   }}</span>
                 </div>
               </div>
-              <p class="text-sm text-gray-700">{{ review.content }}</p>
+              <p class=" text-gray-700 text-sm md:text-lg">{{ review.content }}</p>
               <img
                 v-if="review.imageUrl"
                 :src="review.imageUrl"


### PR DESCRIPTION
Youtube 影片：https://youtu.be/94EyRkBoR7Q

* 修改餐廳詳細頁面的版面
* 修改評論的星星，並加入上傳圖片限制與提示（1MB)、圖片預覽
* 為了切齊，Footer 有再根據餐廳詳細頁面改動（應該就確定下來，不會再改 Footer 了）

餐廳詳細頁面上的三顆按鈕如果以原先的排版，手機畫面容易因為餐廳店名讓版面爆版，
或者讓畫面變得凌亂，所以改成到下一排的顯示方式
<img width="1440" alt="截圖 2025-06-06 晚上7 12 59" src="https://github.com/user-attachments/assets/5bf15080-304a-4062-b857-78a8467cc53f" />
<img width="1440" alt="截圖 2025-06-06 晚上7 13 23" src="https://github.com/user-attachments/assets/ed9b8997-2ca8-414f-bd34-809f9dda76f1" />
<img width="1440" alt="截圖 2025-06-06 晚上7 13 34" src="https://github.com/user-attachments/assets/a9fa7d9b-2267-417a-9594-32f34db5355b" />
<img width="1043" alt="截圖 2025-06-06 晚上7 13 51" src="https://github.com/user-attachments/assets/3f7a0513-fbf8-499b-8cd7-01caaf211bdb" />
<img width="1041" alt="截圖 2025-06-06 晚上7 14 08" src="https://github.com/user-attachments/assets/1ee7cd48-67fa-4b9c-a2b2-a7ec8e604b74" />
<img width="1041" alt="截圖 2025-06-06 晚上7 15 54" src="https://github.com/user-attachments/assets/bde5e225-7d24-4856-8fd5-6dc0c408830e" />

close #208 