### PR TITLE
style:update text truncation on RestaurantDetail and enlarge font on …

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -34,10 +34,10 @@
 
         <!-- 全選 / 全取消 -->
         <div class="flex justify-end gap-2 mb-4">
-          <button class="btn" @click="selectAll">
+          <button class="btn rounded-xl" @click="selectAll">
             {{ t('index.selectAll') }}
           </button>
-          <button class="btn" @click="clearAll">
+          <button class="btn rounded-xl" @click="clearAll">
             {{ t('index.clearAll') }}
           </button>
         </div>
@@ -49,7 +49,7 @@
           <button
             v-for="item in currentOptions"
             :key="item"
-            class="btn btn-sm md:btn-lg rounded-full font-normal"
+            class="btn md:btn-lg rounded-full font-normal text-base md:text-lg"
             @click="toggleCurrent(item)"
             :class="{
               'bg-[var(--color-neutral)] text-white':

--- a/src/views/RestaurantDetail.vue
+++ b/src/views/RestaurantDetail.vue
@@ -27,7 +27,6 @@
       <div class="flex items-center">
         <h1
           class="text-2xl md:text-4xl font-bold md:mt-4 mb-2
-         md:truncate md:max-w-none
          break-words"
         >
           {{ restaurant.name }}


### PR DESCRIPTION
* 餐廳詳細頁面店名折行
Before
<img width="1440" alt="截圖 2025-06-10 上午11 46 40" src="https://github.com/user-attachments/assets/fb5705a2-1f93-4311-8d61-de17f8bb3f67" />
After
<img width="1440" alt="截圖 2025-06-10 上午11 55 30" src="https://github.com/user-attachments/assets/c681f111-2ef9-4a29-ad86-dde276f37385" />
<img width="1002" alt="截圖 2025-06-10 上午11 55 43" src="https://github.com/user-attachments/assets/9865b6ff-7f09-4e71-b295-217151f38644" />

* 手機版的食物選項按鈕、字級調大
<img width="996" alt="截圖 2025-06-10 中午12 07 30" src="https://github.com/user-attachments/assets/7e836433-16cb-46c6-b271-8b07b4a831b8" />

close #234 

