### PR TITLE
refactor: update MyStoreButton  display logic

### DIFF
--- a/src/components/MerchantNavBar.vue
+++ b/src/components/MerchantNavBar.vue
@@ -14,8 +14,9 @@
     </div>
     <div class="flex items-center space-x-3 md:pr-10">
         <RouterLink
-  :to="{ path: `/restaurants/${storeId}` }"
-  class="bg-primary text-white text-sm font-semibold px-4 py-2 hover:bg-neutral transition text-center cursor-pointer rounded-xl justify-center inline-flex items-center gap-1"
+      v-if="storeId"
+      :to="{ path: `/restaurants/${storeId}` }"
+      class="bg-primary text-white text-sm font-semibold px-4 py-2 hover:bg-neutral transition text-center cursor-pointer rounded-xl justify-center inline-flex items-center gap-1"
 >
 
 

--- a/src/components/RestaurantBindModal.vue
+++ b/src/components/RestaurantBindModal.vue
@@ -4,7 +4,7 @@
   >
     <div class="bg-white p-6 rounded-lg shadow-md max-w-md w-full mx-4">
       <!-- 提示標題 -->
-      <div class="mb-4 text-lg md:text-xl font-semibold text-orange-600">
+      <div class="mb-4 text-lg md:text-xl font-semibold text-primary">
         {{ t('restaurantBindModal.title') }}
       </div>
 
@@ -24,7 +24,7 @@
 
       <!-- 關閉 -->
       <div class="mt-6 text-right">
-        <button class="btn btn-base" @click="$emit('close')">
+        <button class="btn btn-base rounded-xl" @click="$emit('close')">
           {{ t('restaurantBindModal.close') }}
         </button>
       </div>

--- a/src/views/MerchantDashboard.vue
+++ b/src/views/MerchantDashboard.vue
@@ -17,7 +17,7 @@
     <!-- 未綁定餐廳提示 -->
     <div
       v-if="!restaurantName || restaurantName.trim().length === 0"
-      class="bg-yellow-100 text-yellow-800 px-4 py-3 rounded-lg mb-6 flex items-center justify-between"
+      class="bg-yellow-100 text-yellow-800 px-4 py-3 rounded-lg mb-6 flex flex-col md:flex-row items-center justify-between"
     >
       <div class="text-base md:text-lg">
         <font-awesome-icon :icon="['fa-solid', 'fa-circle-exclamation']" class="mr-2" />
@@ -27,7 +27,7 @@
       <!-- 新增查看說明的 icon -->
       <button
         @click="showBindModal = true"
-        class="ml-3 px-3 py-1 rounded-md bg-primary text-white hover:brightness-110 text-sm md:text-base min-w-40"
+        class="ml-3 px-3 py-2 rounded-xl bg-primary text-white hover:bg-neutral text-base md:text-lg min-w-40 mt-4 md:mt-0"
         title="{{ t('merchantDashboard.checkRestaurantBindStep') }}"
       >
         {{ t('merchantDashboard.checkRestaurantBindStep') }}


### PR DESCRIPTION
如果商家沒有綁定餐廳，就不會顯示「我的店家」按鈕
<img width="1440" alt="截圖 2025-06-13 上午11 02 26" src="https://github.com/user-attachments/assets/a813f685-5559-4aea-890f-25d666183c99" />

一起更新了這個提示文字的手機版排列方式
<img width="923" alt="截圖 2025-06-13 上午11 29 00" src="https://github.com/user-attachments/assets/4f5b2b32-0373-4e32-9cf4-90d84726dc46" />

